### PR TITLE
fix: enforce max_minutes on late provider responses

### DIFF
--- a/quackd/agent/loop.py
+++ b/quackd/agent/loop.py
@@ -226,6 +226,7 @@ class AgentLoop:
                     usage=turn.usage.model_dump(),
                     stop_reason=turn.stop_reason,
                 )
+                self.budget.check_time()
 
                 if not turn.tool_calls:
                     if not retry_prompted:

--- a/quackd/safety.py
+++ b/quackd/safety.py
@@ -70,6 +70,9 @@ class Budget:
             raise BudgetExceeded(f"max_steps ({self.limits.max_steps}) reached")
         if self.llm_calls >= self.limits.max_llm_calls:
             raise BudgetExceeded(f"max_llm_calls ({self.limits.max_llm_calls}) reached")
+        self.check_time()
+
+    def check_time(self) -> None:
         if self.elapsed_s > self.limits.max_minutes * 60:
             raise BudgetExceeded(f"max_minutes ({self.limits.max_minutes:g}) exceeded")
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from quackd.agent.loop import RunConfig, run_duck
 from quackd.agent.providers.base import Exchange, ProviderTurn, ToolCall
 from quackd.agent.providers.fake import FakeProvider
 from quackd.agent.transcript import Transcript
-from quackd.duckfile.schema import DuckFile
+from quackd.duckfile.schema import Budgets, DuckFile
 from quackd.transport.mock import MockTransport
 
 GOLDEN_HELLO = ["quack", "walk", "quack", "declare_success"]
@@ -53,6 +55,27 @@ class NoToolProvider:
         return ProviderTurn(tool_calls=[], text="I would rather talk.")
 
 
+class ClockAdvancingProvider:
+    name = "clock-advancing"
+    model = "test"
+    supports_vision = False
+
+    def __init__(
+        self, transport: MockTransport, seconds: float, declaration: str = "declare_success"
+    ) -> None:
+        self.transport = transport
+        self.seconds = seconds
+        self.declaration = declaration
+
+    async def step(
+        self, system: str, history: list[Exchange], tools: list[dict[str, Any]]
+    ) -> ProviderTurn:
+        await self.transport.sleep(self.seconds)
+        return ProviderTurn(
+            tool_calls=[ToolCall(name=self.declaration, arguments={"reason": "provider response"})]
+        )
+
+
 async def test_no_tool_call_is_reprompted_once_then_failure(
     hello_duck: DuckFile, tmp_path: Path
 ) -> None:
@@ -63,6 +86,51 @@ async def test_no_tool_call_is_reprompted_once_then_failure(
     )
     assert result.outcome == "failure" and "no tool call" in result.reason
     assert result.llm_calls == 2
+
+
+@pytest.mark.parametrize("declaration", ["declare_success", "declare_failure"])
+async def test_time_budget_wins_over_late_declaration(
+    hello_duck: DuckFile, tmp_path: Path, declaration: str
+) -> None:
+    hello_duck.frontmatter.budgets = Budgets(max_minutes=0.1)
+    transport = MockTransport()
+    result = await run_duck(
+        RunConfig(
+            duck=hello_duck,
+            provider=ClockAdvancingProvider(transport, 7, declaration),
+            transport=transport,
+            runs_dir=tmp_path,
+        )
+    )
+
+    assert result.outcome == "budget"
+    assert result.reason == "max_minutes (0.1) exceeded"
+    assert transport.now() == 7
+    events = Transcript.read(result.run_dir / "transcript.jsonl")
+    kinds = [event["kind"] for event in events]
+    assert "llm" in kinds and "declare" not in kinds
+
+
+async def test_provider_response_before_time_budget_is_processed(
+    hello_duck: DuckFile, tmp_path: Path
+) -> None:
+    hello_duck.frontmatter.budgets = Budgets(max_minutes=0.1, max_llm_calls=1)
+    transport = MockTransport()
+    result = await run_duck(
+        RunConfig(
+            duck=hello_duck,
+            provider=ClockAdvancingProvider(transport, 5),
+            transport=transport,
+            runs_dir=tmp_path,
+        )
+    )
+
+    assert result.outcome == "success"
+    assert result.reason == "provider response"
+    assert result.llm_calls == 1
+    assert transport.now() == 5
+    events = Transcript.read(result.run_dir / "transcript.jsonl")
+    assert "declare" in [event["kind"] for event in events]
 
 
 async def test_budget_ends_the_run(hello_duck: DuckFile, tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Re-check the transport-clock time budget after each provider response and before processing its tool calls.

This prevents late `declare_success` and `declare_failure` responses from bypassing `budgets.max_minutes`, while preserving the existing `max_steps` and `max_llm_calls` counting semantics.

The issue was reproducible with a 6-second `max_minutes` deadline where a provider returned after advancing the mock transport clock to 7 seconds. Before this change, the late `declare_success` was still accepted.

## Kind of change

- [ ] New or changed **verb** (`quackd/verbs/`) — I updated `docs/architecture.md` and `quackd list-verbs` shows it
- [ ] New or changed **`.duck` file** (`ducks/`) — `quackd validate` passes and I ran it with `--provider fake --transport sim2d`
- [ ] Transport / upstream API — every upstream method name is in `quackd/transport/upstream_api.py` marked `VERIFIED` (with a link) or `UNVERIFIED`, and `docs/transport-status.md` is updated
- [ ] Docs only
- [x] Other

## Testing

Added deterministic regression coverage for:

- late `declare_success` after `max_minutes` expiry → `budget`
- late `declare_failure` after `max_minutes` expiry → `budget`
- in-budget provider response → processed normally

The in-budget test also uses `max_llm_calls=1` to ensure the fix does not incorrectly reject the final permitted provider response.

## Checklist

- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy && uv run pytest` pass locally
- [x] No network calls in tests; no API keys needed
- [x] No Pollen Robotics assets (logos, meshes, videos) added
- [ ] CHANGELOG.md updated under *Unreleased*
